### PR TITLE
Testing init.js

### DIFF
--- a/lib/models/design.js
+++ b/lib/models/design.js
@@ -39,7 +39,8 @@ let designModel = function (modelSchema, methods) {
         _modelSchema.attributes  = {};
 
         _.each(modelSchema.properties, function (property, index) {
-          property.defaultValue                                                = property.defaultValue          || false;
+          if (!property.defaultValue) property.defaultValue = (typeof property.defaultValue == 'boolean') ? property.defaultValue : null;
+
           property.unique                                                      = property.unique                || false;
           _modelSchema.attributes[index]                                       = _modelSchema.attributes[index] || {};
           _.each(property, function (el, _index) {

--- a/lib/models/design.js
+++ b/lib/models/design.js
@@ -50,8 +50,8 @@ let designModel = function (modelSchema, methods) {
 
           _modelSchema.attributes[index].type                                  = property.type;
           if (modelSchema.index) _modelSchema.attributes[index].index          = modelSchema.index;
-          if (property.defaultValue) _modelSchema.attributes[index].defaultsTo = property.defaultValue;
-          if (property.defaultValue && property.defaultValue == 'timestamp') _modelSchema.attributes[index].default = Date.now();
+          if (property.defaultValue !== null) _modelSchema.attributes[index].defaultsTo = property.defaultValue;
+          if (property.defaultValue && property.defaultValue == 'timestamp') _modelSchema.attributes[index].defaultsTo = new Date();
         });
 
         if (methods) _modelSchema[methods] = methods[modelSchema.name] ? methods : false || false;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "middleware for your hose",
   "main": "index.js",
   "scripts": {
-    "test": "snyk test",
+    "test": "snyk test && mocha test/*",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"
   },

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
   },
   "devDependencies": {
     "co": "^4.5.4",
+    "co-mocha": "^1.1.3",
     "koa": "^1.2.4",
+    "mocha": "^3.2.0",
     "sails-cassandra": "^0.12.8",
-    "snyk": "^1.21.2",
     "sails-couchdb-orm": "^0.10.3",
-    "sails-mongo": "^0.12.2"
+    "sails-mongo": "^0.12.2",
+    "snyk": "^1.21.2"
   },
   "snyk": true
 }

--- a/test/models/init.t.js
+++ b/test/models/init.t.js
@@ -2,14 +2,14 @@ let mocha = require('mocha')
 let como = require('co-mocha')
 const request = require('request')
 const assert = require('assert')
-const couchdb_url = 'http://localhost:5984'
+const couchdb_url = 'http://localhost:5984/'
 const users_tbl = 'users_wkoa_test'
 
 como(mocha)
 
 //Erlang init:restart()
 function startCouch (done) {
-  request.post(couchdb_url + '/_restart', function (e, r) {
+  request.post(`${couchdb_url}_restart`, function (e, r) {
     if (e) {
       console.log('problem restarting couch')
       throw e
@@ -20,11 +20,11 @@ function startCouch (done) {
 }
 
 function cleanCouch (done) {
-  request.del(couchdb_url + '/' + users_tbl, done)
+  request.del(couchdb_url + users_tbl, done)
 }
 
 function queryCouch (model, query) {
-  request.get(`http://localhost:5984/${model}`, function (err, resp) {
+  request.get(couchdb_url + model, function (err, resp) {
     if (err) throw err
     return query(JSON.parse(resp.body))
   })

--- a/test/models/init.t.js
+++ b/test/models/init.t.js
@@ -1,0 +1,92 @@
+let mocha = require('mocha')
+let como = require('co-mocha')
+const request = require('request')
+const assert = require('assert')
+
+como(mocha)
+
+function startCouch (done) {
+  //Erlang init:restart()
+  request.post('http://localhost:5984/_restart', function (e, r) {
+    if (e) {
+      console.log('problem restarting couch')
+      throw e
+    } else {
+      done()
+    }
+  })
+}
+
+describe('Instantiation', function () {
+    before(function (done) {
+      startCouch(done)
+    })
+
+    let Waterline = require('../..')
+
+    let models = {
+        users: {
+            model: true,
+            adp: 'couch',
+            connection: 'couch',
+            properties: {
+                activated: {
+                    type: 'boolean',
+                    defaultValue: false
+                },
+                verified: {
+                    type: 'boolean',
+                    defaultValue: false
+                },
+                verified_on: {
+                    type: 'string',
+                    defaultValue: 'timestamp'
+                }
+            }
+        }
+    }
+
+    let injection = {
+        methods: false,
+        models: models,
+        connections: {
+            couch: {
+                adapter: "couch",
+                host: '127.0.0.1',
+                port: '5984',
+                username: '',
+                password: ''
+            }
+        },
+        adapters: {
+            couch: require('sails-couchdb-orm')
+        }
+    }
+
+
+    describe('#init()', function () {
+      let waterline, user_definition;
+
+      it('should initialize successfully', function* () {
+        assert(waterline = yield Waterline.init(injection), 'initialized')
+      })
+
+      it('should create connections', function* () {
+      })
+
+      it('should create a collection with given schema', function* (done) {
+        assert(~waterline.connections.couch._collections.indexOf('users'))
+        waterline.connections.couch._adapter.describe(null, 'users', function (err, def) {
+          assert(!err && (user_definition = def))
+          assert(user_definition.activated.defaultsTo == false)
+          done()
+        })
+      })
+
+      it('should fill in default values', function* () {
+        let user = yield waterline.collections.users.create()
+        assert((user.verified === false), 'Default value created')
+        assert((Date.parse(user.verified_on)), 'Default timestamp created')
+      })
+    })
+})

--- a/test/models/init.t.js
+++ b/test/models/init.t.js
@@ -2,91 +2,109 @@ let mocha = require('mocha')
 let como = require('co-mocha')
 const request = require('request')
 const assert = require('assert')
+const couchdb_url = 'http://localhost:5984'
+const users_tbl = 'users_wkoa_test'
 
 como(mocha)
 
+//Erlang init:restart()
 function startCouch (done) {
-  //Erlang init:restart()
-  request.post('http://localhost:5984/_restart', function (e, r) {
+  request.post(couchdb_url + '/_restart', function (e, r) {
     if (e) {
       console.log('problem restarting couch')
       throw e
     } else {
-      done()
+      cleanCouch(done)
     }
   })
 }
 
+function cleanCouch (done) {
+  request.del(couchdb_url + '/' + users_tbl, done)
+}
+
+function queryCouch (model, query) {
+  request.get(`http://localhost:5984/${model}`, function (err, resp) {
+    if (err) throw err
+    return query(JSON.parse(resp.body))
+  })
+}
+
 describe('Instantiation', function () {
-    before(function (done) {
-      startCouch(done)
+  before(function (done) {
+    startCouch(done)
+  })
+
+  let Waterline = require('../..')
+
+  let models = {
+      users_wkoa_test: {
+          model: true,
+          adp: 'couch',
+          connection: 'couch',
+          properties: {
+              activated: {
+                  type: 'boolean',
+                  defaultValue: false
+              },
+              verified: {
+                  type: 'boolean',
+                  defaultValue: false
+              },
+              verified_on: {
+                  type: 'string',
+                  defaultValue: 'timestamp'
+              }
+          }
+      }
+  }
+
+  let injection = {
+      methods: false,
+      models: models,
+      connections: {
+          couch: {
+              adapter: "couch",
+              host: '127.0.0.1',
+              port: '5984',
+              username: '',
+              password: ''
+          }
+      },
+      adapters: {
+          couch: require('sails-couchdb-orm')
+      }
+  }
+
+
+  describe('#init()', function () {
+    let waterline, user_definition;
+
+    it('should initialize successfully', function* () {
+      assert(waterline = yield Waterline.init(injection), 'initialized')
     })
 
-    let Waterline = require('../..')
-
-    let models = {
-        users: {
-            model: true,
-            adp: 'couch',
-            connection: 'couch',
-            properties: {
-                activated: {
-                    type: 'boolean',
-                    defaultValue: false
-                },
-                verified: {
-                    type: 'boolean',
-                    defaultValue: false
-                },
-                verified_on: {
-                    type: 'string',
-                    defaultValue: 'timestamp'
-                }
-            }
-        }
-    }
-
-    let injection = {
-        methods: false,
-        models: models,
-        connections: {
-            couch: {
-                adapter: "couch",
-                host: '127.0.0.1',
-                port: '5984',
-                username: '',
-                password: ''
-            }
-        },
-        adapters: {
-            couch: require('sails-couchdb-orm')
-        }
-    }
-
-
-    describe('#init()', function () {
-      let waterline, user_definition;
-
-      it('should initialize successfully', function* () {
-        assert(waterline = yield Waterline.init(injection), 'initialized')
-      })
-
-      it('should create connections', function* () {
-      })
-
-      it('should create a collection with given schema', function* (done) {
-        assert(~waterline.connections.couch._collections.indexOf('users'))
-        waterline.connections.couch._adapter.describe(null, 'users', function (err, def) {
-          assert(!err && (user_definition = def))
-          assert(user_definition.activated.defaultsTo == false)
-          done()
-        })
-      })
-
-      it('should fill in default values', function* () {
-        let user = yield waterline.collections.users.create()
-        assert((user.verified === false), 'Default value created')
-        assert((Date.parse(user.verified_on)), 'Default timestamp created')
+    it('should create connections', function (done) {
+      queryCouch(users_tbl, function (body) {
+        assert(body.doc_count == 0, 'test db cleared')
+        assert(body.db_name == users_tbl, 'test db created')
+        done()
       })
     })
+
+    it('should create a collection with given schema', function (done) {
+      assert(~waterline.connections.couch._collections.indexOf(users_tbl))
+      waterline.connections.couch._adapter.describe(null, users_tbl, function (err, def) {
+        assert(!err && (user_definition = def))
+        assert(user_definition.activated.defaultsTo == false)
+        done()
+      })
+    })
+
+    it('should fill in default values', function* () {
+      let user = yield waterline.collections[users_tbl].create()
+      assert((user.verified === false), 'Default value created')
+      assert((Date.parse(user.verified_on)), 'Default timestamp created')
+    })
+  })
 })


### PR DESCRIPTION
Probably should call something external to verify the DB connection. Maybe another HTTP request to couch.

Additionally, using `_restart` could very well not work in many environments. MacOs does not have `init.d` though so I think this makes sense for now.


There is a fix included here to setting `defaultValue`, as `false` values would fall through before.